### PR TITLE
Minor Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ All of this section are passed verbatim through to `sacli`.
 * `vpn_tls_refresh_do_reauth` - 
 * `vpn_tls_refresh_interval` - 
 * `xmlrpc_relay_level` - 
+- `vpn_server_dhcp_option_dns_0` -
+- `vpn_server_dhcp_option_domain` -
+
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ In the example below `certificate.yml` is an [Ansible Vault], contains the `cs_c
 - hosts: openvpnas
   become: true
   vars:
-    ldap_auth_ldap_0_namename: vpn.example.com
-    ldap_auth_ldap_0_server_0_hostserver_0: ldap.example.com
+    auth_ldap_0_name: vpn.example.com
+    auth_ldap_0_server_0_host: ldap.example.com
     auth_ldap_0_bind_dn: administrator@ldap.example.com
     auth_ldap_0_bind_pw: superstrongpassword
     auth_ldap_0_users_base_dn: cn=Users,dc=ldap,dc=example,dc=com

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 # object, and uses the variable passed into the role of that name.
 # (Escaped quotes are to ensure the second param is passed as a single option)
 - name: Set the sacli options
-  command: "config-set {{ item.key }} \"{{ vars[item.value] }}\""
+  command: "config-set {{ item.key }} \"{{ lookup('vars', item.value) }}\""
   register: output
   changed_when: output.stdout != 'EXISTS'
   notify: restart

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -66,3 +66,5 @@ keys:
   - {key: "vpn.tls_refresh.do_reauth", value: "vpn_tls_refresh_do_reauth"}
   - {key: "vpn.tls_refresh.interval", value: "vpn_tls_refresh_interval"}
   - {key: "xmlrpc.relay_level", value: "xmlrpc_relay_level"}
+  - {key: "vpn.server.dhcp_option.dns.0", value: "vpn_server_dhcp_option_dns_0"}
+  - {key: "vpn.server.dhcp_option.domain", value: "vpn_server_dhcp_option_domain"}


### PR DESCRIPTION
A couple of minor updates:

- Support extra keys to set client DNS settings.
- Use the `lookup` command so that variables can include Jinja2 syntax. Previously, if one had defined a variable referencing another variable (e.g. `host_name: "vpn.{{ domain_name }}"`), then Jinja2 syntax would be sent literally into the config set command. Now, it will properly expanded as expected.